### PR TITLE
feat: display user data upon account creation

### DIFF
--- a/App.js
+++ b/App.js
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   Image,
+  Alert,
 } from 'react-native';
 import {Picker} from '@react-native-picker/picker';
 import Slider from '@react-native-community/slider';
@@ -25,6 +26,26 @@ class App extends Component {
       accountlimit: 0,
       student: false,
     };
+
+    this.showData = this.showData.bind(this);
+  }
+
+  showData() {
+    if (
+      this.state.name &&
+      this.state.age &&
+      this.state.genderSelected &&
+      this.state.accountlimit != ''
+    ) {
+      alert(`Conta Criada com sucesso!\n
+            Nome: ${this.state.name}\n
+            Idade: ${this.state.age}\n
+            Sexo: ${this.state.genderSelected.gender}\n
+            Limite da conta: ${this.state.accountlimit.toFixed(0)}\n
+            Estudante: ${this.state.student ? `Sim` : `Não`}`);
+    } else {
+      alert('Campos preenchidos incorretamentes');
+    }
   }
 
   render() {
@@ -61,7 +82,7 @@ class App extends Component {
 
             <View style={styles.select}>
               <Picker
-                selectedValue={this.state.genderSelected.gender}
+                selectedValue={this.state.genderSelected}
                 onValueChange={(itemValue, itemIndex) =>
                   this.setState({genderSelected: itemValue})
                 }>
@@ -103,7 +124,7 @@ class App extends Component {
             </View>
           </View>
 
-          <TouchableOpacity style={styles.btn}>
+          <TouchableOpacity style={styles.btn} onPress={this.showData}>
             <Text style={styles.btnText}>Criar Conta</Text>
           </TouchableOpacity>
         </View>


### PR DESCRIPTION
## What happened? 📝
implement functionality to display the collected user information (name, age, gender, account limit, student status) on the screen after the "Create Account" button is pressed. this provides immediate feedback to the user.

## Screenshots 📸
| all fields filled in                                                                                                                               | without all fields filled in                                                                                                                                  |
| :--------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img src="https://github.com/user-attachments/assets/ba52d894-90c8-4354-a807-e1b9efb04024" width="200" alt="Screenshot with all fields filled in"> | <img src="https://github.com/user-attachments/assets/1689702c-5a1b-48f4-8b28-690070837bde" width="200" alt="Screenshot without all fields filled in"> |

## What kind of change? 🏗
- [x] New thing (change that adds something new, doesn't break things)
- [ ] Fixed problem (change that fixes something that wasn't right, doesn't break things)
- [ ] Made better (change that cleans up the code or makes it work better, doesn't break things)
- [ ] Small job (not like the others, like making libraries newer)
- [ ] Testing (making sure things work right)
- [x] Big change 🚨
## Things to check 🧐
- [ ] Checked on iOS
- [x] Checked on Android